### PR TITLE
Used <article> to enclose self-containing compositions

### DIFF
--- a/_includes/technology-progress.html
+++ b/_includes/technology-progress.html
@@ -1,4 +1,4 @@
-<div class="my-progress">
+<article class="my-progress">
     <div class="my-progress__technology" data-level="{{ include.level }}">
         {% assign svg_content = include.svg %}
       {{ svg_content | replace: '<svg', '<svg class="my-progress__technology-icon"' }}
@@ -7,5 +7,5 @@
         <div class="my-progress__progress-bar"></div>
       </div>
     </div>
-  </div>
+  </article>
   

--- a/index.html
+++ b/index.html
@@ -44,13 +44,13 @@
         <div class="section--carousel_hidder">
           <div class="section--carousel">
             {% for post in site.posts %}
-            <div class="section--post">
+            <article class="section--post">
               <h3 class="post--title">Project {{ forloop.index }} of {{ forloop.length }}:  {{
                 post.title }}</h3>
               <div class="post_content">
                 {{ post.content }}
               </div>
-            </div>
+            </article>
             {% endfor %}
           </div>
         </div>


### PR DESCRIPTION
**Context**
There are compositions that represent projects on the page.  Also, we keep display info on the knowledge level we have on certain programming technologies.

**Problem**
Those are currently enclosed using the generic container `<div>`, which is only appropriate for compositions grouped only for styling purposes. However, we noticed there is a better HTML element for such items: `<article>`.

**Solution**
Enclose the project descriptions with the `<article>` element.