### PR TITLE
Removed unnecessary markup

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -77,14 +77,11 @@
 
 .page_body--section:first-child {
     margin-top: 90px;
+    overflow: hidden;
 }
 
 .section--subtitle {
     font-size: 0.98rem;
-}
-
-.section--carousel_hidder {
-    overflow: hidden;
 }
 
 .section--carousel {

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
     <div class="page_body">
       <section class="page_body--section">
         <h2 class="section--subtitle">Projects</h2>
-        <div class="section--carousel_hidder">
+      
           <div class="section--carousel">
             {% for post in site.posts %}
             <article class="section--post">
@@ -53,7 +53,6 @@
             </article>
             {% endfor %}
           </div>
-        </div>
         <button class="carousel_contollers carousel_prev">Prev</button>
         <button class="carousel_contollers carousel_next">Next</button>
       </section>
@@ -136,7 +135,6 @@
     slides[currentSlide].classList.add('active');
 
     prevButton.addEventListener('click', () => {
-      console.log("Handling click")
       slides[currentSlide].classList.remove('active');
       currentSlide = (currentSlide - 1 + slides.length) % slides.length;
       slides[currentSlide].classList.add('active');
@@ -151,7 +149,6 @@
     });
 
     function move() {
-      console.log("Moving by " + (currentSlide * carousel.clientWidth))
       const amountToMove = currentSlide * carousel.clientWidth;
       carousel.style.left = -amountToMove + "px";
     }


### PR DESCRIPTION
**Context**
I display a carousel slide with my projects. 

**Problem**
The markup for the carousel seems a little bit too much.

**Solution**
Removed the carousel hidder element. Now the `overflow: hidden` is placed in the section element envolving the carousel. 